### PR TITLE
Fix LoggingCardTerminal$LoggingCard$LoggingCardChannel::transmit(ByteBuffer, ByteBuffer) not to alter ByteBuffer state

### DIFF
--- a/pcsc/src/main/java/apdu4j/terminals/LoggingCardTerminal.java
+++ b/pcsc/src/main/java/apdu4j/terminals/LoggingCardTerminal.java
@@ -311,7 +311,7 @@ public class LoggingCardTerminal extends CardTerminal {
                 int position = buffer.position();
                 boolean needsFlip = position != offset;
                 int dataLength = needsFlip
-                        ? buffer.position() - offset
+                        ? position - offset
                         : buffer.limit() - offset;
                 return Arrays.copyOfRange(buffer.array(), offset, dataLength);
             }


### PR DESCRIPTION
The ByteBuffer state should not be altered while retrieving data